### PR TITLE
chore(scripts): change shebangs to bash

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,5 @@ docs
 node_modules
 
 LICENSE
+aliases
 *.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         files: \.[jt]sx?$
         types: [file]
   - repo: https://github.com/clairBuoyant/pre-commit
-    rev: v0.1.2
+    rev: v0.2.0
     hooks:
       - id: branch-validate
   - repo: https://github.com/commitizen-tools/commitizen

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 ## Development
 
-Run all [documented commands](./scripts/README.md) from the project's **root** folder.
-
-For example, once all system dependencies are installed you may run:
-`npm run init` to complete the prerequisite setup.
+[Scripts](./scripts/README.md) are provided to support the development experience. For best results, please run these commands from the project's **root** folder.
 
 ### System Dependencies
 
@@ -13,7 +10,11 @@ Install the following required dependencies before proceeding further.
 
 #### Required
 
-- [NodeJS >= 18.7](https://www.python.org/downloads/release/python-3105): primary language for web application.
+- [NodeJS >= 18.7](https://nodejs.org/en/download/current/): primary language for web application.
+- [pre-commit](https://pre-commit.com/#install): manage githooks.
+  - Recommended installation methods:
+    - [`pipx`](https://pypa.github.io/pipx/)
+    - [`brew`](https://brew.sh/)
 
 #### Recommended
 
@@ -21,16 +22,42 @@ Install the following required dependencies before proceeding further.
 
 ### Getting Started
 
-Run `npm run init` in your terminal to get started.
+For your initial setup (or if you just want to make sure you remain in sync during development), run `npm run init` in your terminal to get started like so:
+
+```shell
+# executes scripts/bootstrap and scripts/setup.
+npm run init
+
+# start development server locally
+npm run start
+```
+
+Alternatively, you may load script aliases to your current shell and execute them without `npm` like so:
+
+Recommended usage:
+
+```shell
+# add scripts aliases to current shell.
+. ./aliases
+
+# executes scripts/bootstrap and scripts/setup.
+init
+
+# start development server locally
+start
+```
+
+UI will be available at [localhost:3000](http://localhost:3000/) when running app locally.
 
 #### Working with npm
 
+Some of `npm`'s most frequently used commands are documented below:
+
 1. Install dependencies: `npm install`
 
-2. Run commands or scripts: `npm run <command_or_script_name>`
+2. Run custom commands or scripts: `npm run <command_name>`
 
-3. Start development server locally: `npm run start`
-   - UI will be available at [localhost:3000](http://localhost:3000/).
+If you'd like to learn more about `npm`, check out [this informative blog post](https://nodesource.com/blog/an-absolute-beginners-guide-to-using-npm/).
 
 ### Development with Docker
 

--- a/aliases
+++ b/aliases
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+#
+# Load scripts to current shell environment for execution without package manager.
+
+PROJECT_ROOT=$(realpath $(dirname "$BASH_SOURCE"))
+
+function bootstrap() {
+    ${PROJECT_ROOT}/scripts/bootstrap
+}
+function clean() {
+    ${PROJECT_ROOT}/scripts/clean
+}
+function init() {
+    ${PROJECT_ROOT}/scripts/init
+}
+function setup() {
+    ${PROJECT_ROOT}/scripts/setup
+}
+function start() {
+    ${PROJECT_ROOT}/scripts/start
+}
+function uninstall() {
+    ${PROJECT_ROOT}/scripts/uninstall
+}
+
+echo 'Script commands are ready to use in current shell environment.'

--- a/package.json
+++ b/package.json
@@ -32,12 +32,6 @@
     "test": "react-scripts test",
     "uninstall": "./scripts/uninstall"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",
@@ -49,5 +43,12 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "packageManager": "npm@8.16.0"
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,21 +2,27 @@
 
 These scripts are provided for development of [clairBuoyant](https://www.github.com/clairBuoyant). The script names are standardized across all repositories for clairBuoyant to simplify the development experience.
 
-### Commands
+### Available Commands
 
-- `bootstrap` - Prepare local development environment.
-- `clean` - Delete any build artifacts.
-- `init` - Execute bootstrap and setup for initial setup.
-- `setup` - Initial setup for development dependencies.
-- `start` - Start server locally.
-- `uninstall` - Delete all dependencies and build artifacts.
+- `bootstrap`: resolve all system dependencies the application needs to run.
+- `clean`: remove all unnecessary build artifacts.
+- `init`: run bootstrap and setup.
+- `setup`: install node dependencies and githooks.
+- `start`: start app locally.
+- `uninstall`: remove node dependencies and build artifacts.
 
 ### Usage
 
-The two recommended ways to interact with these scripts are directly or with poetry in your terminal.
+These scripts can be used directly or with `npm` (**recommended**).
 
-1. Run script directly: `./scripts/<name>` (e.g., `./scripts/init`)
-2. Run with npm: `npm run <name>` (e.g., `npm run init`)
+1. Run with npm: `npm run <command_name>` (e.g., `npm run init`).
+2. Run script directly:
+  - `./scripts/<command_name>` (e.g., `./scripts/init`).
+  - Run `. ./aliases` in your terminal in order to run any script just by `<command_name>` (e.g., `init` or `start`). <sup>1</sup>
+
+#### Note
+
+1. This script needs to be re-run every time you start a new terminal session. But, it saves you from prepending `npm run` every time! :)
 
 ### Attribution
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,49 +1,32 @@
-#!/bin/sh -e
+#!/bin/bash -e
 #
 # Resolve all system dependencies the application needs to run.
-
-echo "ABOUT BOOTSTRAP
-Ensures your NodeJS and Python versions are compatible.
-
-Installs the following required dependencies:
-    - pipx (https://pypa.github.io/pipx/)
-    - pre-commit with pipx (https://pre-commit.com/)
-"
-
-read -p "Would you like to proceed? (y/n) " -n 1 -r
-echo # move to a new line
-if [[ ! $REPLY =~ ^[Yy]$ ]]
-then
-    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
-fi
-
 
 PYV=`python3 -c 'import sys; sys.stdout.write("true") if sys.version_info.major >= 3 and sys.version_info.minor >= 10 else sys.stdout.write("false");'`
 if ! $PYV
 then
-    echo "Python version 3.10 or greater is required."
+    echo 'Python version 3.10 or greater is required.'
     exit 1
 fi
 
 JSV=`node -e 'const [major, minor] = process.version.slice(1).split(".").map(n => Number(n)); major >= 18 && minor >= 7 ? console.log("true") : console.log("false");'`
 if ! $JSV
 then
-    echo "Node version 18.7 or greater is required."
+    echo 'Node version 18.7 or greater is required.'
     exit 1
 fi
 
-
-echo "[REQUIRED] Checking for pipx..."
-if ! command -v pipx &> /dev/null
-then
-    echo "pipx was not found. Installing..."
-    python3 -m pip install --user pipx
-    python3 -m pipx ensurepath
-fi
-
-echo "[REQUIRED] Checking for pre-commit..."
+echo 'Checking for pre-commit...'
 if ! command -v pre-commit &> /dev/null
 then
-    echo "pre-commit not found. Installing with pipx..."
+    echo 'pre-commit not found. Installing with pipx...'
+    if ! command -v pipx &> /dev/null
+    then
+        echo 'pipx was not found. Installing pipx first...'
+        python3 -m pip install --user pipx
+        python3 -m pipx ensurepath
+    fi
     pipx install pre-commit
 fi
+
+echo 'System dependencies installed.'

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash -ex
+#
+# Remove all build artifacts.
 
 if [ -d 'build' ] ; then
     rm -r build

--- a/scripts/init
+++ b/scripts/init
@@ -1,4 +1,9 @@
-#!/bin/sh -e
+#!/bin/bash -e
+#
+# Prepare application for development by running bootstrap and setup.
 
-./scripts/bootstrap
-./scripts/setup
+CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR="$(dirname "$CURRENT_DIR")"
+
+${BASE_DIR}/scripts/bootstrap
+${BASE_DIR}/scripts/setup

--- a/scripts/run
+++ b/scripts/run
@@ -1,4 +1,6 @@
-#!/bin/sh -e
+#!/bin/bash -e
+#
+# Docker entrypoint.
 
 case $1 in
     start)

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,6 +1,7 @@
-#!/bin/sh -ex
+#!/bin/bash -e
+#
+# Install node dependencies and githooks.
 
-command -v pre-commit &> /dev/null && pre-commit install --hook-type commit-msg || echo >&2 "pre-commit not found."
+command -v pre-commit &> /dev/null && pre-commit install --hook-type commit-msg || echo >&2 'pre-commit not found.'
 
 npm ci
-# npm link

--- a/scripts/start
+++ b/scripts/start
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash -e
+#
+# Start application locally.
 
 # The '| cat' is to trick Node that this is an non-TTY terminal
 # then react-scripts won't clear the console.

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -1,8 +1,11 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
+#
+# Remove node dependencies and build artifacts.
 
-# npm -g unlink
+CURRENT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BASE_DIR="$(dirname "$CURRENT_DIR")"
 
-./scripts/clean
+${BASE_DIR}/scripts/clean
 
 if [ -d 'node_modules' ] ; then
     rm -r node_modules


### PR DESCRIPTION
## Description

Update scripts shebangs to `bash` from `sh` and add `./aliases` script as an alternative to executing scripts with package manager. [README was updated](https://github.com/clairBuoyant/web/pull/19/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R47) to provide additional information.

## Related Issues

Related to #16