### PR TITLE
fix: `BASE_API_URL` value to support deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "bootstrap": "./scripts/bootstrap",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "clean": "./scripts/clean",
     "dev": "vite",
     "init": "./scripts/init",
@@ -85,13 +85,13 @@
         "<rootDir>/src/hooks/index.ts"
       ],
       "@layouts/(.*)": [
-        "<rootDir>/src/layouts/*"
+        "<rootDir>/src/layouts/$1"
       ],
       "@types": [
         "<rootDir>/src/types/index.ts"
       ],
       "@views/(.*)": [
-        "<rootDir>/src/views/*"
+        "<rootDir>/src/views/$1"
       ],
       "\\.(css|less|scss|sass)$": "identity-obj-proxy"
     },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,8 +3,10 @@ export const NODE_ENV = {
   PRODUCTION: 'production',
 };
 
+const BASE_API_URL = import.meta.env.DEV ? 'http://127.0.0.1:8888' : 'https://clairbuoyant.live';
+
 export const API_VERSION = 'v1';
-export const BASE_API_URI = `http://localhost:8888/api/${API_VERSION}`;
+export const BASE_API_URI = `${BASE_API_URL}/api/${API_VERSION}`;
 export const API_ROUTES = {
   BUOYS: `${BASE_API_URI}/buoys`,
   COASTLINES: `${BASE_API_URI}/coastlines`,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,11 @@ export default defineConfig({
     },
   },
   plugins: [react(), process.env.BUILD_MODE ? false : eslintPlugin()],
+  preview: {
+    port: 3000,
+  },
   server: {
+    host: '127.0.0.1',
     port: 3000,
   },
 });


### PR DESCRIPTION
### Summary

- [x] Dynamically set BASE_API_URL by `import.meta.env` (proxy for `NODE_ENV`).
- [x] Set preview port to dev server port to simplify CORS management.
- [x] Fix glob patterns in jest config for `moduleNameMapper`.